### PR TITLE
Project Release Compile on Arch Linux

### DIFF
--- a/src/Gui/Renderer.cpp
+++ b/src/Gui/Renderer.cpp
@@ -59,7 +59,7 @@ void Renderer::render()
 
 	ImGui::Image((ImTextureID)texture(), m_render_size, { 0, 1 }, { 1, 0 });
 	char buf[64];
-	sprintf_s(buf, 64, "%.4f %.4f %.4f", camera().location().x, camera().location().y, camera().location().z);
+	sprintf(buf, "%.4f %.4f %.4f", camera().location().x, camera().location().y, camera().location().z);
 	const auto text_size = ImGui::CalcTextSize(buf);
 	ImGui::SetNextWindowSize({ text_size.x + 50.f, 60.0f });
 	ImGui::SetNextWindowPos({ m_render_location.x, m_render_location.y });

--- a/src/Gui/RendererOptions.cpp
+++ b/src/Gui/RendererOptions.cpp
@@ -16,7 +16,7 @@ void RendererOptions::render() {
             int i = 0;
             char buf[50];
             for(auto& unknown_vector_array : Editor::the().level_file()->unknown_vector_arrays()) {
-                sprintf_s(buf, 50, "Unknown Array %d", i++);
+                sprintf(buf, "Unknown Array %d", i++);
                 if (ImGui::CollapsingHeader(buf)) {
                     ImGui::Indent();
                     ImGui::Checkbox("Should Render", &unknown_vector_array.m_should_draw);

--- a/src/Renderer/Shader.cpp
+++ b/src/Renderer/Shader.cpp
@@ -3,6 +3,7 @@
 #include <glad/glad.h>
 #include <memory>
 #include <cstring>
+#include <vector>
 
 void Shader::make_gl_shader(Shader& shader, std::string_view vs, std::string_view fs)
 {
@@ -46,7 +47,7 @@ void Shader::make_gl_shader(Shader& shader, std::string_view vs, std::string_vie
 
     if (!is) {
         int maxLength = 5000;
-        std::vector<GLchar> infoLog(maxLength);
+        std::vector<GLchar> infoLog = std::vector<GLchar>(maxLength);
         glGetProgramInfoLog(program, maxLength, &maxLength, &infoLog[0]);
     }
 

--- a/src/Structs/sly_level_structs.cpp
+++ b/src/Structs/sly_level_structs.cpp
@@ -20,7 +20,7 @@ mesh_data_t::mesh_data_t(ez_stream& stream, unsigned char field_0x40)
             not_flags_and_1.vertex_data[i] = std::move(vertex_data_t(stream, offset));
         }
 
-        magic a = stream.read<::magic>();
+        magic_t a = stream.read<::magic_t>();
         if(!a.is_szme()) {
             m_error = true;
         }
@@ -347,7 +347,7 @@ szme_t::szme_t(ez_stream &stream, uint16_t flags, unsigned char field_0x40)
     {
         flags_not_and_1.mesh_count = stream.read<uint16_t>();
         if (flags_not_and_1.mesh_count > 2000)
-            throw std::exception("let's not");
+            throw std::runtime_error("let's not");
         flags_not_and_1.szme_data.resize(flags_not_and_1.mesh_count);
         for(int i = 0; i < flags_not_and_1.mesh_count; i++)
         {

--- a/src/Structs/sly_level_structs.h
+++ b/src/Structs/sly_level_structs.h
@@ -21,7 +21,7 @@ struct normal_t {
     float x{0.0f}, y{0.0f}, z{0.0f};
  };
 
-struct magic {
+struct magic_t {
     char magic[4];
 
     bool is_szme() const {
@@ -98,7 +98,7 @@ struct vertex_data_t
 
 struct szms_header_t
 {
-    magic magic;
+    magic_t magic;
     uint32_t version;
     uint32_t data_size;
 };
@@ -289,7 +289,7 @@ struct szme_t {
     szme_t(ez_stream& stream, uint16_t flags, unsigned char field_0x40);
 
     bool m_error{ false };
-    magic magic;
+    magic_t magic;
 
     struct {
         uint32_t unk_0x04;
@@ -360,7 +360,7 @@ struct mesh_data_t
         std::vector<vertex_data_t> vertex_data;
         std::vector<render_properties> render_properties_vector;
 
-        magic magic;
+        magic_t magic;
     } not_flags_and_1;
 
     struct {

--- a/src/Utility/FileWriter.h
+++ b/src/Utility/FileWriter.h
@@ -18,7 +18,7 @@ public:
     void write(const T* ptr, size_t size) {
         //rewrite this also
         const auto path = std::filesystem::current_path();
-        std::ofstream file = std::ofstream(path / m_loc, std::ios::out | std::ios::binary | std::ios::beg);
+        std::ofstream file = std::ofstream(path / m_loc);
         if (file.is_open()) {
             m_was_opened = true;
             file.write((const char*)ptr, size);


### PR DESCRIPTION
Ran into a number of issues trying to build the project on my system. They're listed here along with commits to fix them.

<details>
<summary> Variable named `magic`, Type named `magic`</summary>

```
 [ 62%] Building CXX object CMakeFiles/cane.dir/src/main.cpp.o
 In file included from /home/sugaku/Desktop/cane/src/Structs/SlyLevelFile.h:5,
                  from /home/sugaku/Desktop/cane/src/main.cpp:25:
 /home/sugaku/Desktop/cane/src/Structs/sly_level_structs.h:101:11: error: declaration of ‘magic szms_header_t::magic’ changes meaning of ‘magic’ [-fpermissive]
   101 |     magic magic;
      |           ^~~~~
/home/sugaku/Desktop/cane/src/Structs/sly_level_structs.h:24:8: note: ‘magic’ declared here as ‘struct magic’
   24 | struct magic {
      |        ^~~~~
/home/sugaku/Desktop/cane/src/Structs/sly_level_structs.h:292:11: error: declaration of ‘magic szme_t::magic’ changes meaning of ‘magic’ [-fpermissive]
  292 |     magic magic;
      |           ^~~~~
/home/sugaku/Desktop/cane/src/Structs/sly_level_structs.h:24:8: note: ‘magic’ declared here as ‘struct magic’
   24 | struct magic {
      |        ^~~~~
/home/sugaku/Desktop/cane/src/Structs/sly_level_structs.h:363:15: error: declaration of ‘magic mesh_data_t::<unnamed struct>::magic’ changes meaning of ‘magic’ [-fpermissive]
  363 |         magic magic;
      |               ^~~~~
/home/sugaku/Desktop/cane/src/Structs/sly_level_structs.h:24:8: note: ‘magic’ declared here as ‘struct magic’
   24 | struct magic {
      |        ^~~~~
make[2]: *** [CMakeFiles/cane.dir/build.make:76: CMakeFiles/cane.dir/src/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:158: CMakeFiles/cane.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

a0009715c7fee7c2cf8dc3f47e5921bf12cb2e14
</details>

<details>
<summary> Non-existent basic_std::ofstream Constructor </summary>

https://en.cppreference.com/w/cpp/io/basic_ofstream/basic_ofstream

```
[ 62%] Building CXX object CMakeFiles/cane.dir/src/Utility/config.cpp.o
In file included from /home/sugaku/Desktop/cane/src/Utility/config.cpp:3:
/home/sugaku/Desktop/cane/src/Utility/FileWriter.h: In member function ‘void FileWriter::write(const T*, size_t)’:
/home/sugaku/Desktop/cane/src/Utility/FileWriter.h:21:91: warning: bitwise operation between different enumeration types ‘std::_Ios_Openmode’ and ‘const std::ios_base::seekdir’ is deprecated [-Wdeprecated-enum-enum-conversion]
   21 |         std::ofstream file = std::ofstream(path / m_loc, std::ios::out | std::ios::binary | std::ios::beg);
      |                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/home/sugaku/Desktop/cane/src/Utility/FileWriter.h: In instantiation of ‘void FileWriter::write(const T*, size_t) [with T = config; size_t = long unsigned int]’:
/home/sugaku/Desktop/cane/src/Utility/config.cpp:11:17:   required from here
/home/sugaku/Desktop/cane/src/Utility/FileWriter.h:21:91: warning: bitwise operation between different enumeration types ‘std::_Ios_Openmode’ and ‘const std::ios_base::seekdir’ is deprecated [-Wdeprecated-enum-enum-conversion]
/home/sugaku/Desktop/cane/src/Utility/FileWriter.h:21:35: error: no matching function for call to ‘std::basic_ofstream<char>::basic_ofstream(std::filesystem::__cxx11::path, int)’
   21 |         std::ofstream file = std::ofstream(path / m_loc, std::ios::out | std::ios::binary | std::ios::beg);
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/sugaku/Desktop/cane/src/Utility/FileReader.h:3,
                 from /home/sugaku/Desktop/cane/src/Utility/config.cpp:2:
/usr/include/c++/12.1.0/fstream:847:9: note: candidate: ‘template<class _Path, class _Require> std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const _Path&, std::ios_base::openmode) [with _Require = _Path; _CharT = char; _Traits = std::char_traits<char>]’
  847 |         basic_ofstream(const _Path& __s,
      |         ^~~~~~~~~~~~~~
```

42d70b7a5efda2bc370058ae4a7838f4fe4514fc
</details>